### PR TITLE
tasks/24569176-c11685071-make-build-linux-failure --- enable devel mo…

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -32,6 +32,7 @@ module:
   datetime: 0
   datetime_range: 0
   dblog: 0
+  devel: 0
   display_field_copy: 0
   ds_devel: 0
   ds_switch_view_mode: 0


### PR DESCRIPTION
The make build_linux commad was failing because config/sync/core.extensions.yml was specifying that two modules that depend on the devel module are enabled, ds_devel and webprofiler, without devel itself being enabled. The fix here is to add devel back into the list of enabled modules. This is consistent with esmero/archipelago-deployment. I'm not sure why it came to be removed in [this commit](https://github.com/Born-Digital-US/archipelago-deployment/commit/b6885ae3563ec2b69551ae32b5a189fb13d3e482#diff-c74373ec0d30209248deac631a2a6db007924814cb51f9a620a807fbcb30de1dL35).